### PR TITLE
Add typescript interfaces for coding activity events/heartbeats

### DIFF
--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -19,6 +19,7 @@ export interface AppEditorActivityHeartbeat extends Heartbeat {
         project: string;    // Path to the current project / workDir
         file: string;       // Path to the current file
         language: string;   // Coding Language identifier (e.g. javascript, python, ...)
+        [k: string]: any;   // Additional (custom) data
     }
 }
 export interface AppEditorActivityEvent extends AppEditorActivityHeartbeat {

--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -2,14 +2,26 @@ import axios, { AxiosInstance, AxiosPromise } from 'axios';
 
 const isNode = (typeof module !== 'undefined' && module.exports);
 
+// Default interfaces for events and heartbeats
 export interface Heartbeat {
     id?: number;
     timestamp: string;    // timestamp as iso8601 string
     duration?: number;    // duration in seconds
     data: { [k: string]: any };
 }
-
 export interface Event extends Heartbeat {
+    duration: number;
+}
+
+// Interfaces for coding activity
+export interface AppEditorActivityHeartbeat extends Heartbeat {
+    data: {
+        project: string;    // Path to the current project / workDir
+        file: string;       // Path to the current file
+        language: string;   // Coding Language identifier (e.g. javascript, python, ...)
+    }
+}
+export interface AppEditorActivityEvent extends AppEditorActivityHeartbeat {
     duration: number;
 }
 


### PR DESCRIPTION
I think it would be useful to add a typescript interface for coding activities to (1) document the standard format and (2) to kind of enforce this standard in typescript.

If we intend to make more of these standard event formats, we should consider moving them into a separate file (e.g. aw-events-interfaces.ts), so we don't pollute the aw-client.ts file with these interfaces.