### PR TITLE
Removed custom user agent

### DIFF
--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -1,7 +1,5 @@
 import axios, { AxiosInstance, AxiosPromise } from 'axios';
 
-const isNode = (typeof module !== 'undefined' && module.exports);
-
 // Default interfaces for events and heartbeats
 export interface Heartbeat {
     id?: number;
@@ -58,7 +56,6 @@ class AWClient {
         this.req = axios.create({
             baseURL: baseurl + '/api',
             timeout: 10000,
-            headers: (!isNode) ? {} : { 'User-Agent': 'aw-client-js/0.1' }
         });
 
         // Make 304 not an error (necessary for create bucket requests)


### PR DESCRIPTION
So I removed the custom user agent.

First I started doing this because the isNode check didn't work with browserify since that made module to actually be defined, so in aw-watcher-web we tried to set the user-agent all the time but the browser denied it and used their default. Nothing critical here but were annoying warnings in the console.

So my question is, why did we set it in the first place? If we don't set it the only difference is that aw-watcher-vscode will report the user-agent "axios" instead of "aw-client-js" which is fine IMO.