### PR TITLE
insert and replace event no longer has a return value

### DIFF
--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -138,23 +138,16 @@ export class AWClient {
         return this.req.get("/0/buckets/" + bucketId + "/events/count", { params });
     }
 
-    public async insertEvent(bucketId: string, event: IEvent): Promise<IEvent> {
-        return this.insertEvents(bucketId, [event]).then(events => events[0]);
+    public async insertEvent(bucketId: string, event: IEvent): Promise<void> {
+        return this.insertEvents(bucketId, [event]);
     }
 
-    public async insertEvents(bucketId: string, events: IEvent[]): Promise<IEvent[]> {
-        let insertedEvents = (await this.req.post("/0/buckets/" + bucketId + "/events", events)).data;
-        if (!Array.isArray(insertedEvents)) {
-            insertedEvents = [insertedEvents];
-        }
-        insertedEvents.forEach((event: IEvent) => {
-            event.timestamp = new Date(event.timestamp);
-        });
-        return insertedEvents;
+    public async insertEvents(bucketId: string, events: IEvent[]): Promise<void> {
+        await this.req.post("/0/buckets/" + bucketId + "/events", events);
     }
 
     // Just an alias for insertEvent requiring the event to have an ID assigned
-    public async replaceEvent(bucketId: string, event: IEvent): Promise<IEvent> {
+    public async replaceEvent(bucketId: string, event: IEvent): Promise<void> {
         if(event.id === undefined) {
             throw("Can't replace event without ID assigned")
         }


### PR DESCRIPTION
If we are returning the inserted or replaced events in aw-server it is
impossible to use transactions in the database as that makes the commit
of the events lazy so no ID is decided at the end of the request.

My suggestion is to remove the return body from the API completely as
that gives much better I/O performance for aw-server.