### PR TITLE
Heartbeats should not return anything else than success/failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: node_js
+dist: bionic
 node_js:
- - "6"
  - "8"
  - "node"
 
-env: PYENV_VERSION='3.5.4'
-
 before_install:
- - "wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/0.4.0/setup-pyenv.sh"
- - "source setup-pyenv.sh"
+ - "pyenv global 3.7"
  - "python3 -V"
- - "pip install git+https://github.com/ActivityWatch/aw-core.git"
- - "pip install git+https://github.com/ActivityWatch/aw-server.git"
+ - "pip3 install git+https://github.com/ActivityWatch/aw-core.git"
+ - "pip3 install git+https://github.com/ActivityWatch/aw-server.git"
 
 install:
  - "make build"

--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -29,7 +29,7 @@ export interface IBucket {
 }
 
 interface IHeartbeatQueueItem {
-    onSuccess: (heartbeat: IEvent) => void;
+    onSuccess: () => void;
     onError: (err: AxiosError) => void;
     pulsetime: number;
     heartbeat: IEvent;
@@ -173,7 +173,7 @@ export class AWClient {
      *                  with the previous heartbeat in aw-server
      * @param heartbeat The actual heartbeat event
      */
-    public heartbeat(bucketId: string, pulsetime: number, heartbeat: IEvent): Promise<IEvent> {
+    public heartbeat(bucketId: string, pulsetime: number, heartbeat: IEvent): Promise<undefined> {
         // Create heartbeat queue for bucket if not already existing
         if (!this.heartbeatQueues.hasOwnProperty(bucketId)) {
             this.heartbeatQueues[bucketId] = {
@@ -221,7 +221,7 @@ export class AWClient {
             queue.isProcessing = true;
             this.send_heartbeat(bucketId, pulsetime, heartbeat)
                 .then((response) => {
-                    onSuccess(response);
+                    onSuccess();
                     queue.isProcessing = false;
                     this.updateHeartbeatQueue(bucketId);
                 })

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -96,7 +96,6 @@ describe("All", () => {
         }))
         .then(([ firstResponse ]) => {
             console.log("heartbeat", firstResponse);
-            assert.equal(testevent.data.label, firstResponse.data.label);
         });
     });
 


### PR DESCRIPTION
If we want to be able to return the returning heartbeat from the API we are
forced to commit the database on every heartbeat. This drains a lot of performance
and is disabled on aw-server-rust and on aw-server-python with the sqlite
datastore for this reason. Doing such small writes is especially damaging for
HDDs, but the wakeups for SSDs also take a lot of IO performance and battery.

We do not have any use-case for this feature today anyway, so I think we should drop it.