### PR TITLE
Changes the baseURL to be localhost instead of 127.0.0.1

### DIFF
--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -59,7 +59,7 @@ export class AWClient {
         this.testing = options.testing || false;
         if (typeof options.baseURL === "undefined") {
             const port = !options.testing ? 5600 : 5666;
-            this.baseURL = `http://127.0.0.1:${port}`;
+            this.baseURL = `http://localhost:${port}`;
         } else {
           this.baseURL = options.baseURL;
         }


### PR DESCRIPTION
This is important because aw-watcher-web re-uses the baseURL and we want the button in the web-ui to point to the same page as aw-qt (which is localhost, not 127.0.0.1). Settings such as categories are not shared between 127.0.0.1 and localhost.