### PR TITLE
ci: update workflow to use v4 actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,13 +18,13 @@ jobs:
         aw-version: [0.12.3b15]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache activitywatch binaries
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./activitywatch
         key: ${{ runner.os }}-activitywatch-${{ matrix.aw-version }}
@@ -48,7 +48,7 @@ jobs:
         node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions workflow in `nodejs.yml` to use v4 of `checkout`, `setup-node`, and `cache` actions.
> 
>   - **Workflow Updates**:
>     - Update `actions/checkout` to `v4` in `nodejs.yml`.
>     - Update `actions/setup-node` to `v4` in `nodejs.yml` for the `build` job.
>     - Update `actions/cache` to `v4` in `nodejs.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-client-js&utm_source=github&utm_medium=referral)<sup> for dfed50b2203d693c1ea4cea3e18193970a0deefa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->