### PR TITLE
feat(client): add Bearer token auth support via AWReqOptions.token

### DIFF
--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -41,6 +41,7 @@ export interface AWReqOptions {
     testing?: boolean;
     baseURL?: string;
     timeout?: number;
+    token?: string;
 }
 
 interface IBucketRaw {
@@ -166,6 +167,7 @@ export class AWClient {
     public apiURL: string;
     public timeout: number;
     public testing: boolean;
+    public token: string | undefined;
 
     public controller: AbortController;
 
@@ -181,6 +183,7 @@ export class AWClient {
         this.clientname = clientname;
         this.testing = options.testing ?? false;
         this.timeout = options.timeout ?? 30000;
+        this.token = options.token;
         if (typeof options.baseURL === "undefined") {
             const port = !options.testing ? 5600 : 5666;
             // Note: had to switch to 127.0.0.1 over localhost as otherwise there's
@@ -197,6 +200,10 @@ export class AWClient {
         this.queryCache = {};
     }
 
+    private _authHeaders(): HeadersInit {
+        return this.token ? { Authorization: `Bearer ${this.token}` } : {};
+    }
+
     /// Fetching logic
     /** Makes a GET request, assuming the response is JSON and parsing it */
     private async _get<T>(endpoint: string, params: RequestInit = {}) {
@@ -204,6 +211,7 @@ export class AWClient {
             `${this.apiURL}${endpoint}`,
             {
                 ...params,
+                headers: { ...this._authHeaders(), ...(params.headers ?? {}) },
                 signal: this.controller.signal,
             },
             this.timeout,
@@ -216,7 +224,7 @@ export class AWClient {
             {
                 method: "POST",
                 signal: this.controller.signal,
-                headers: { "Content-Type": "application/json" },
+                headers: { "Content-Type": "application/json", ...this._authHeaders() },
                 body: JSON.stringify(data),
             },
             this.timeout,
@@ -229,6 +237,7 @@ export class AWClient {
             {
                 method: "DELETE",
                 signal: this.controller.signal,
+                headers: { ...this._authHeaders() },
             },
             this.timeout,
         );

--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -200,7 +200,7 @@ export class AWClient {
         this.queryCache = {};
     }
 
-    private _authHeaders(): HeadersInit {
+    private _authHeaders(): Record<string, string> {
         return this.token ? { Authorization: `Bearer ${this.token}` } : {};
     }
 

--- a/src/aw-client.ts
+++ b/src/aw-client.ts
@@ -224,7 +224,10 @@ export class AWClient {
             {
                 method: "POST",
                 signal: this.controller.signal,
-                headers: { "Content-Type": "application/json", ...this._authHeaders() },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...this._authHeaders(),
+                },
                 body: JSON.stringify(data),
             },
             this.timeout,


### PR DESCRIPTION
## Summary

Adds opt-in Bearer token authentication to `AWClient`. When a `token` is passed
in `AWReqOptions`, every outgoing request includes `Authorization: Bearer <token>`.

- New `token?: string` field on `AWReqOptions` and stored as `public token: string | undefined`
- Private `_authHeaders()` helper returns `{ Authorization: ... }` when set, `{}` when not
- `_get`, `_post`, and `_delete` merge auth headers into every request

The field is **opt-in and backward-compatible**: existing callers that don't pass `token`
see no change in behavior.

## Motivation

Part of the ActivityWatch API auth rollout (ActivityWatch/activitywatch#1199).

- `aw-server-rust#585` shipped opt-in Bearer token auth in the server
- `aw-client` (Python) already handles this via ActivityWatch/aw-client#106 (merged)
- This PR brings the same capability to the JS client so browser-based consumers
  (aw-watcher-web, aw-webui) can authenticate

## Consumers

- **aw-watcher-web**: companion PR ActivityWatch/aw-watcher-web#next reads the API key
  from extension storage and passes it as `{ token }` to `AWClient`
- **aw-webui**: already uses `aw-client` via Axios with its own auth-header injection;
  this opens the door for callers that use `AWClient.fetch` directly

## Test plan

- [ ] `new AWClient('test', { token: 'abc' })` → `_get('/foo')` sends `Authorization: Bearer abc`
- [ ] `new AWClient('test')` → no `Authorization` header sent (backward compat)
- [ ] `new AWClient('test', { token: 'abc' })` then `client.token = ''` → header removed on next call